### PR TITLE
use dockerfile v2 and add webservice

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,4 +16,9 @@ RUN pip install --no-cache-dir -r requirements.txt
 ENV TARTARE_RABBITMQ_HOST amqp://guest:guest@localhost:5672//
 RUN chown -R daemon:daemon /usr/src/app
 USER daemon
+
+# you can pass a TARTARE_VERSION to the build (with cli argument --build-arg or in docker-compose)
+ARG TARTARE_VERSION
+ENV TARTARE_VERSION ${TARTARE_VERSION:-unknown_version}
+
 CMD ["celery", "-A", "tartare.tasks.celery", "worker"]

--- a/README.md
+++ b/README.md
@@ -29,6 +29,9 @@ honcho start
 
 We use a docker image for deployment purpose.
 
+Note: we use the new interface version of docker-compose, so docker version needs to be >= 1.10,
+ docker-compose version needs to be >= 1.6
+ 
 ``` bash
 cd path/to/tartare
 docker-compose build

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,22 +1,46 @@
-tartare_worker:
-  build: .
-  environment:
-    - TARTARE_RABBITMQ_HOST=amqp://guest:guest@rabbitmq:5672//
-  command: celery -A tartare.tasks.celery worker
-  volumes:
-    - /tmp/tartare/input:/var/tartare/input
-    - /tmp/tartare/output:/var/tartare/output
-    - /tmp/tartare/current:/var/tartare/current
-  links:
-    - rabbitmq
+version: '2'
 
-tartare_beat:
-  build: .
-  environment:
-    - TARTARE_RABBITMQ_HOST=amqp://guest:guest@rabbitmq:5672//
-  command: celery -A tartare.tasks.celery beat
-  links:
-    - rabbitmq
+services:
+  tartare_worker:
+    build:
+      context: .
+      args:
+        TARTARE_VERSION: ${TARTARE_VERSION}
+    environment:
+      - TARTARE_RABBITMQ_HOST=amqp://guest:guest@rabbitmq:5672//
+    command: celery -A tartare.tasks.celery worker
+    volumes:
+      - /tmp/tartare/input:/var/tartare/input
+      - /tmp/tartare/output:/var/tartare/output
+      - /tmp/tartare/current:/var/tartare/current
+    links:
+      - rabbitmq
 
-rabbitmq:
-  image: rabbitmq:management
+  tartare_beat:
+    build:
+      context: .
+      args:
+        TARTARE_VERSION: ${TARTARE_VERSION}
+    environment:
+      - TARTARE_RABBITMQ_HOST=amqp://guest:guest@rabbitmq:5672//
+    command: celery -A tartare.tasks.celery beat
+    links:
+      - rabbitmq
+
+  tartare_webservice:
+    build:
+      context: .
+      args:
+        TARTARE_VERSION: ${TARTARE_VERSION}
+    environment:
+      - TARTARE_RABBITMQ_HOST=amqp://guest:guest@rabbitmq:5672//
+      - FLASK_APP=tartare/api.py
+    command: flask run --host=0.0.0.0
+    links:
+      - rabbitmq
+    ports:
+      - "5000:5000"
+
+  rabbitmq:
+    image: rabbitmq:management
+


### PR DESCRIPTION
the docker compose v1 is deprecated, translate it to use v2.

docker's version need to be >= 1.10
docker-compose version need to be >= 1.6

also add a environment variable to give the tartare's version

the version will be given using `git describe` when building the docker image