### PR TITLE
use a custom celery exchange not to mess with others

### DIFF
--- a/tartare/default_settings.py
+++ b/tartare/default_settings.py
@@ -12,6 +12,8 @@ CELERY_BROKER_URL = str(os.getenv('TARTARE_RABBITMQ_HOST', 'amqp://guest:guest@l
 
 CELERY_DEFAULT_QUEUE = 'tartare'
 
+CELERY_DEFAULT_EXCHANGE = 'celery_tartare'
+
 #configuration of celery, don't edit
 CELERY_ACCEPT_CONTENT = ['pickle', 'json']
 


### PR DESCRIPTION
if we use the same rabbitmq than other app (like navitia's tyr), we
don't want to use the same exchange