### PR TITLE
Do not mount backup dir as volume

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,12 +2,14 @@ FROM python:3.4-alpine
 
 VOLUME /var/tartare/input
 VOLUME /var/tartare/output
-VOLUME /var/tartare/current
+#VOLUME /var/tartare/current
 
 ENV TARTARE_INPUT /var/tartare/input
 ENV TARTARE_OUTPUT /var/tartare/output
 ENV TARTARE_CURRENT /var/tartare/current
 
+RUN mkdir -p /var/tartare/
+RUN chown -R daemon:daemon /var/tartare/
 
 # those are needed for uwsgi
 RUN apk --update add \

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,9 +8,10 @@ ENV TARTARE_INPUT /var/tartare/input
 ENV TARTARE_OUTPUT /var/tartare/output
 ENV TARTARE_CURRENT /var/tartare/current
 
+
 # those are needed for uwsgi
 RUN apk --update add \
-        gcc \
+        g++ \
         build-base \
         python-dev \
         zlib-dev \
@@ -26,6 +27,17 @@ COPY ./tartare /usr/src/app/tartare
 COPY requirements.txt /usr/src/app
 WORKDIR /usr/src/app
 RUN pip install --no-cache-dir -r requirements.txt
+
+RUN apk del \
+        g++ \
+        build-base \
+        python-dev \
+        zlib-dev \
+        linux-headers \
+        musl \
+        musl-dev \
+        memcached \
+        libmemcached-dev
 
 ENV TARTARE_RABBITMQ_HOST amqp://guest:guest@localhost:5672//
 RUN chown -R daemon:daemon /usr/src/app

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,9 +10,8 @@ services:
       - TARTARE_RABBITMQ_HOST=amqp://guest:guest@rabbitmq:5672//
     command: celery -A tartare.tasks.celery worker
     volumes:
-      - /tmp/tartare/input:/var/tartare/input
-      - /tmp/tartare/output:/var/tartare/output
-      - /tmp/tartare/current:/var/tartare/current
+      - /tmp/tartare/input:/var/tartare/input:rw
+      - /tmp/tartare/output:/var/tartare/output:rw
     links:
       - rabbitmq
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -33,8 +33,7 @@ services:
         TARTARE_VERSION: ${TARTARE_VERSION}
     environment:
       - TARTARE_RABBITMQ_HOST=amqp://guest:guest@rabbitmq:5672//
-      - FLASK_APP=tartare/api.py
-    command: flask run --host=0.0.0.0
+    command: uwsgi --mount /=tartare:app --http 0.0.0.0:5000
     links:
       - rabbitmq
     ports:


### PR DESCRIPTION
there are some permission mess, we temporary remove `tartare/current` as a volume
(anyway I think we'll soon stop using filesystem as backup)

+ some minor docker fixes
