### PR TITLE
upgrade celery version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 amqp==1.4.9
 anyjson==0.3.3
 billiard==3.3.0.23
-celery==3.1.7
+celery==3.1.23
 click==6.6
 Flask==0.11.1
 Flask-RESTful==0.3.5


### PR DESCRIPTION
we have some strange 'clock out of sync' problem between the workers
because of the timezones of the different machine

seems to be corrected in newer celery version:
https://github.com/celery/celery/issues/1802