### PR TITLE
Changed route api post calendar

### DIFF
--- a/tartare/api.py
+++ b/tartare/api.py
@@ -36,6 +36,6 @@ from flask_restful import Api
 from tartare.interfaces.status import Status
 
 api = Api(app)
-api.add_resource(GridCalendar, '/grid_calendar')
+api.add_resource(GridCalendar, '/coverages/<string:coverage_id>/grid_calendar')
 api.add_resource(Status, '/status')
 api.add_resource(Coverage, '/coverages', '/coverages/', '/coverages/<string:coverage_id>')

--- a/tartare/interfaces/coverages.py
+++ b/tartare/interfaces/coverages.py
@@ -29,7 +29,6 @@
 from flask_restful import reqparse, abort
 import flask_restful
 from pymongo.errors import PyMongoError
-from tartare import mongo
 from tartare.core import models
 import logging
 from tartare.interfaces import schema

--- a/tartare/interfaces/grid_calendar.py
+++ b/tartare/interfaces/grid_calendar.py
@@ -36,7 +36,6 @@ import os
 from flask.globals import request
 from flask_restful import Resource
 from tartare import app
-from werkzeug.utils import secure_filename
 import shutil
 
 GRID_CALENDARS = "grid_calendars.txt"
@@ -81,7 +80,7 @@ def check_files_header(zip_file):
 
 
 class GridCalendar(Resource):
-    def post(self):
+    def post(self, coverage_id):
         if not request.files:
             return {'message': 'the archive is missing'}, 400
         content = request.files['file']

--- a/tests/integration/rest_api_test.py
+++ b/tests/integration/rest_api_test.py
@@ -40,7 +40,7 @@ def test_post_grid_calendar_returns_success_status(app):
     filename = 'export_calendars.zip'
     path = os.path.join(os.path.dirname(os.path.dirname(__file__)), 'fixtures/gridcalendar/', filename)
     files = {'file': (open(path, 'rb'), 'export_calendars.zip')}
-    raw = app.post('/grid_calendar', data=files)
+    raw = app.post('/coverages/jdr/grid_calendar', data=files)
     r = to_json(raw)
     input_dir = os.path.join(tartare.app.config.get("INPUT_DIR"))
     assert raw.status_code == 200
@@ -52,7 +52,7 @@ def test_post_grid_calendar_returns_non_compliant_file_status(app):
     path = os.path.join(os.path.dirname(os.path.dirname(__file__)),
                         'fixtures/gridcalendar/export_calendars_with_invalid_header.zip')
     files = {'file': (open(path, 'rb'), 'export_calendars.zip')}
-    raw = app.post('/grid_calendar', data=files)
+    raw = app.post('/coverages/jdr/grid_calendar', data=files)
     r = to_json(raw)
     assert raw.status_code == 400
     assert r.get('message') == 'non-compliant file(s) : grid_periods.txt'
@@ -62,14 +62,14 @@ def test_post_grid_calendar_returns_file_missing_status(app):
     path = os.path.join(os.path.dirname(os.path.dirname(__file__)),
                         'fixtures/gridcalendar/export_calendars_without_grid_calendars.zip')
     files = {'file': (open(path, 'rb'), 'export_calendars.zip')}
-    raw = app.post('/grid_calendar', data=files)
+    raw = app.post('/coverages/jdr/grid_calendar', data=files)
     r = to_json(raw)
     assert raw.status_code == 400
     assert r.get('message') == 'file(s) missing : grid_calendars.txt'
 
 
 def test_post_grid_calendar_returns_archive_missing_message(app):
-    raw = app.post('/grid_calendar')
+    raw = app.post('/coverages/jdr/grid_calendar')
     r = to_json(raw)
     assert raw.status_code == 400
     assert r.get('message') == 'the archive is missing'


### PR DESCRIPTION
We now need the coverage when posting a calendar.
I changed the route 
/grid_calendar to /coverage/{coverage_id}/grid_calendar