### PR TITLE
Add environments on coverage 

### DIFF
--- a/tartare/core/models.py
+++ b/tartare/core/models.py
@@ -37,7 +37,7 @@ def init_mongo():
     mongo.db['contributors'].ensure_index("data_prefix", unique=True)
 
 
-class Environmnent(object):
+class Environment(object):
     def __init__(self, tyr_url=None, name=None):
         self.name = name
         self.tyr_url = tyr_url
@@ -111,12 +111,17 @@ class MongoEnvironmentSchema(Schema):
 
     @post_load
     def make_environment(self, data):
-        return Environmnent(**data)
+        return Environment(**data)
 
 class MongoEnvironmentListSchema(Schema):
-    production = fields.Nested(MongoEnvironmentSchema)
-    preproduction = fields.Nested(MongoEnvironmentSchema)
-    integration = fields.Nested(MongoEnvironmentSchema)
+    production = fields.Nested(MongoEnvironmentSchema, allow_none=True)
+    preproduction = fields.Nested(MongoEnvironmentSchema, allow_none=True)
+    integration = fields.Nested(MongoEnvironmentSchema, allow_none=True)
+
+    @post_load
+    def remove_none(self, data):
+        #We don't want to keep removed environments
+        return {key: value for key, value in data.items() if value is not None}
 
 
 class MongoCoverageSchema(Schema):

--- a/tartare/default_settings.py
+++ b/tartare/default_settings.py
@@ -46,6 +46,12 @@ INPUT_DIR = str(os.getenv('TARTARE_INPUT', './input'))
 OUTPUT_DIR = str(os.getenv('TARTARE_OUTPUT', './output'))
 CURRENT_DATA_DIR = str(os.getenv('TARTARE_CURRENT', './current'))
 
+#If no environment is defined at the creation of a coverage tyr create automaticaly the enviroment typed "production"
+#The folowing parameters will be used for creating it
+DEFAULT_ENVIRONMENT_NAME = str(os.getenv('TARTARE_DEFAULT_ENVIRONMENT_NAME', 'production'))
+#in the URL the placeholder "{coverage}" will be replaced by the coverage name
+DEFAULT_ENVIRONMENT_TYR_URL_TEMPLATE = str(os.getenv('TARTARE_DEFAULT_ENVIRONMENT_TYR_URL_TEMPLATE', 'http://tyr.prod/v0/coverage/{coverage}/'))
+
 # GRID_CALENDAR_DIR is just the name of the directory where is a calendar file
 # The absolute path is CURRENT_DATA_DIR/grid_calendar
 GRID_CALENDAR_DIR = 'grid_calendar'

--- a/tartare/interfaces/schema.py
+++ b/tartare/interfaces/schema.py
@@ -31,8 +31,9 @@
 from functools import wraps
 from flask_restful import unpack
 from marshmallow import Schema, fields, post_load, validates_schema, ValidationError
-from tartare.core.models import MongoCoverageSchema, Coverage, MongoCoverageTechnicalConfSchema
-from tartare.core.models import MongoContributorSchema
+
+from tartare.core.models import MongoCoverageSchema, Coverage, MongoCoverageTechnicalConfSchema, MongoEnvironmentSchema, MongoEnvironmentListSchema
+from tartare.core.models import MongoContributorSchema, Environment
 import os
 from tartare import app
 
@@ -64,10 +65,21 @@ class CoverageTechnicalConfSchema(MongoCoverageTechnicalConfSchema, NoUnknownFie
     #we just need NoUnknownFieldMixin for validation purpose
     pass
 
+class EnvironmentSchema(MongoEnvironmentSchema, NoUnknownFieldMixin):
+    pass
+
+class EnvironmentListSchema(MongoEnvironmentListSchema, NoUnknownFieldMixin):
+    production = fields.Nested(EnvironmentSchema, allow_none=True)
+    preproduction = fields.Nested(EnvironmentSchema, allow_none=True)
+    integration = fields.Nested(EnvironmentSchema, allow_none=True)
+
+
+
 class CoverageSchema(MongoCoverageSchema, NoUnknownFieldMixin):
     id = fields.String(required=True)
     #we have to override nested field to add validation on input
     technical_conf = fields.Nested(CoverageTechnicalConfSchema)
+    environments = fields.Nested(EnvironmentListSchema)
 
 
     @post_load
@@ -86,6 +98,13 @@ class CoverageSchema(MongoCoverageSchema, NoUnknownFieldMixin):
                              ('current_data_dir', 'CURRENT_DATA_DIR')):
             setattr(data['technical_conf'], arg, getattr(data.get('technical_conf', {}), arg) \
                                                  or _default_dir(env_var, data['id']))
+
+        envs = data.get('environments', {})
+        if not envs.get('production') and not envs.get('preproduction') and not envs.get('integration'):
+            env = Environment(name=app.config.get('DEFAULT_ENVIRONMENT_NAME'),
+                        tyr_url=app.config.get('DEFAULT_ENVIRONMENT_TYR_URL_TEMPLATE').format(coverage=data['id']))
+            data['environments'] = {}
+            data['environments']['production'] = env
         return Coverage(**data)
 
 class ContributorSchema(MongoContributorSchema, NoUnknownFieldMixin):


### PR DESCRIPTION
Each coverage can have three environments, one of each types:
  - production
  - preproduction
  - integration

For now an environments has a name and an URL for the corresponding tyr

We could create a new endpoint (nested in coverage) for managing environments, it will be more complex to implements but allow us to do a prettier URL for data_update:
With this PR the url should look like this: `/coverages/fr-idf/data_update?environment=production`
with a new endpoint will could do this: `/coverages/fr-idf/environments/production/data_update`