### PR TITLE
Usage of gridFS for storing grid_calendars 

### DIFF
--- a/tartare/api.py
+++ b/tartare/api.py
@@ -46,5 +46,6 @@ api.add_resource(Index, '/', endpoint='index')
 api.add_resource(Status, '/status', endpoint='status')
 api.add_resource(Coverage, '/coverages', '/coverages/', '/coverages/<string:coverage_id>', endpoint='coverages')
 api.add_resource(GridCalendar, '/coverages/<string:coverage_id>/grid_calendar', endpoint='grid_calendar')
-api.add_resource(DataUpdate, '/coverages/<string:coverage_id>/data_update', endpoint='data_update')
+api.add_resource(DataUpdate, '/coverages/<string:coverage_id>/environments/<string:environment_type>/data_update',
+                             endpoint='data_update')
 api.add_resource(Contributor, '/contributors', '/contributors/<string:contributor_id>')

--- a/tartare/core/models.py
+++ b/tartare/core/models.py
@@ -31,14 +31,9 @@ from marshmallow import Schema, fields, post_load
 from tartare import app
 from tartare.helper import to_doted_notation
 from gridfs import GridFS
-from gridfs.grid_file import GridOut
 from bson.objectid import ObjectId
 import logging
 
-#monkey patching og gridfs file for exposing the size in a standard way
-def grid_out_len(self):
-    return self.length
-GridOut.__len__ = grid_out_len
 
 @app.before_first_request
 def init_mongo():
@@ -47,7 +42,6 @@ def init_mongo():
 def save_file_in_gridfs(file, gridfs=None, **kwargs):
     if not gridfs:
         gridfs = GridFS(mongo.db)
-    logging.debug('file: %s, kwargs: %s', file, kwargs)
     return str(gridfs.put(file, **kwargs))
 
 def get_file_from_gridfs(id, gridfs=None):

--- a/tartare/core/models.py
+++ b/tartare/core/models.py
@@ -31,19 +31,41 @@ from marshmallow import Schema, fields, post_load
 from tartare import app
 from tartare.helper import to_doted_notation
 from gridfs import GridFS
+from gridfs.grid_file import GridOut
 from bson.objectid import ObjectId
 import logging
 
+#monkey patching og gridfs file for exposing the size in a standard way
+def grid_out_len(self):
+    return self.length
+GridOut.__len__ = grid_out_len
 
 @app.before_first_request
 def init_mongo():
     mongo.db['contributors'].ensure_index("data_prefix", unique=True)
 
+def save_file_in_gridfs(file, gridfs=None, **kwargs):
+    if not gridfs:
+        gridfs = GridFS(mongo.db)
+    logging.debug('file: %s, kwargs: %s', file, kwargs)
+    return str(gridfs.put(file, **kwargs))
+
+def get_file_from_gridfs(id, gridfs=None):
+    if not gridfs:
+        gridfs = GridFS(mongo.db)
+    return gridfs.get(ObjectId(id))
+
+def delete_file_from_gridfs(id, gridfs=None):
+    if not gridfs:
+        gridfs = GridFS(mongo.db)
+    return gridfs.delete(ObjectId(id))
+
 
 class Environment(object):
-    def __init__(self, tyr_url=None, name=None):
+    def __init__(self, tyr_url=None, name=None, current_ntfs_id=None):
         self.name = name
         self.tyr_url = tyr_url
+        self.current_ntfs_id = current_ntfs_id
 
 class Coverage(object):
     mongo_collection = 'coverages'
@@ -66,18 +88,19 @@ class Coverage(object):
 
     def save_grid_calendars(self, file):
         gridfs = GridFS(mongo.db)
-        id = gridfs.put(file)
-        Coverage.update(self.id, {'grid_calendars_id': str(id)})
+        filename = '{coverage}_calendars.zip'.format(coverage=self.id)
+        id = save_file_in_gridfs(file, gridfs=gridfs, filename=filename, coverage=self.id)
+        Coverage.update(self.id, {'grid_calendars_id': id})
         #when we delete the file all process reading it will get invalid data
         #TODO: We will need to implement a better solution
-        gridfs.delete(ObjectId(self.grid_calendars_id))
+        delete_file_from_gridfs(self.grid_calendars_id, gridfs=gridfs)
         self.grid_calendars_id = id
 
     def get_grid_calendars(self):
         if not self.grid_calendars_id:
             return None
         gridfs = GridFS(mongo.db)
-        return gridfs.get(ObjectId(self.grid_calendars_id))
+        return get_file_from_gridfs(self.grid_calendars_id)
 
 
     def save(self):
@@ -115,6 +138,18 @@ class Coverage(object):
 
         return cls.get(coverage_id)
 
+    def save_ntfs(self, environment_type, file):
+        if environment_type not in self.environments.keys():
+            raise ValueError('invalid value for environment_type')
+        filename = '{coverage}_{type}_ntfs.zip'.format(coverage=self.id, type=environment_type)
+        gridfs = GridFS(mongo.db)
+        id = save_file_in_gridfs(file, gridfs=gridfs, filename=filename, coverage=self.id)
+        Coverage.update(self.id, {'Environments.{}.current_ntfs_id'.format(environment_type): id})
+        #when we delete the file all process reading it will get invalid data
+        #TODO: We will need to implements a better solution
+        delete_file_from_gridfs(self.environments[environment_type].current_ntfs_id)
+        self.environments[environment_type].current_ntfs_id = id
+
 
 class MongoCoverageTechnicalConfSchema(Schema):
     input_dir = fields.String()
@@ -128,6 +163,7 @@ class MongoCoverageTechnicalConfSchema(Schema):
 class MongoEnvironmentSchema(Schema):
     name = fields.String(required=True)
     tyr_url = fields.Url()
+    current_ntfs_id = fields.String(allow_none=True)
 
     @post_load
     def make_environment(self, data):

--- a/tartare/core/models.py
+++ b/tartare/core/models.py
@@ -144,7 +144,7 @@ class Coverage(object):
         filename = '{coverage}_{type}_ntfs.zip'.format(coverage=self.id, type=environment_type)
         gridfs = GridFS(mongo.db)
         id = save_file_in_gridfs(file, gridfs=gridfs, filename=filename, coverage=self.id)
-        Coverage.update(self.id, {'Environments.{}.current_ntfs_id'.format(environment_type): id})
+        Coverage.update(self.id, {'environments.{}.current_ntfs_id'.format(environment_type): id})
         #when we delete the file all process reading it will get invalid data
         #TODO: We will need to implements a better solution
         delete_file_from_gridfs(self.environments[environment_type].current_ntfs_id)

--- a/tartare/helper.py
+++ b/tartare/helper.py
@@ -34,6 +34,12 @@ import sys
 from collections.abc import Mapping
 import requests
 from requests_toolbelt.multipart import encoder
+from gridfs.grid_file import GridOut
+
+#monkey patching of gridfs file for exposing the size in a "standard" way
+def grid_out_len(self):
+    return self.length
+GridOut.__len__ = grid_out_len
 
 def upload_file(url, filename, file):
     form = encoder.MultipartEncoder({

--- a/tartare/interfaces/data_update.py
+++ b/tartare/interfaces/data_update.py
@@ -66,13 +66,12 @@ class DataUpdate(Resource):
                 logger.warning('invalid file provided: %s', content.filename)
                 return {'message': 'invalid file provided: {}'.format(content.filename)}, 400
             with open(tmp_file, 'rb') as file:
-                if file_type == 'fusio':
+                if data_handler.is_ntfs_data(file_type):
                     coverage.save_ntfs(environment_type, file)
-                    tasks.update_ntfs.delay(coverage_id, environment_type)
+                    tasks.send_ntfs_to_tyr.delay(coverage_id, environment_type)
                 else:
                     #we need to temporary save the file before sending it
-                    logging.debug('%s', file)
                     file_id = models.save_file_in_gridfs(file, filename=content.filename)
-                    tasks.send_file.delay(coverage_id, environment_type, file_id)
+                    tasks.send_file_to_tyr_and_discard.delay(coverage_id, environment_type, file_id)
 
         return {'message': 'Valid {} file provided : {}'.format(file_type, file_name)}, 200

--- a/tartare/interfaces/data_update.py
+++ b/tartare/interfaces/data_update.py
@@ -66,7 +66,7 @@ class DataUpdate(Resource):
                 logger.warning('invalid file provided: %s', content.filename)
                 return {'message': 'invalid file provided: {}'.format(content.filename)}, 400
             with open(tmp_file, 'rb') as file:
-                if file_type == 'ntfs':
+                if file_type == 'fusio':
                     coverage.save_ntfs(environment_type, file)
                     tasks.update_ntfs.delay(coverage_id, environment_type)
                 else:

--- a/tartare/interfaces/grid_calendar.py
+++ b/tartare/interfaces/grid_calendar.py
@@ -107,6 +107,9 @@ class GridCalendar(Resource):
         zip_file.close()
 
         #run the update of navitia in background
-        tasks.update_calendars.delay(coverage.id)
+        for k, env in coverage.environments.items():
+            if env.current_ntfs_id:
+                #TODO: use a chain later
+                tasks.update_ntfs.delay(coverage.id, k)
 
         return {'message': 'OK'}, 200

--- a/tartare/interfaces/grid_calendar.py
+++ b/tartare/interfaces/grid_calendar.py
@@ -110,6 +110,6 @@ class GridCalendar(Resource):
         for k, env in coverage.environments.items():
             if env.current_ntfs_id:
                 #TODO: use a chain later
-                tasks.update_ntfs.delay(coverage.id, k)
+                tasks.send_ntfs_to_tyr.delay(coverage.id, k)
 
         return {'message': 'OK'}, 200

--- a/tartare/interfaces/schema.py
+++ b/tartare/interfaces/schema.py
@@ -66,7 +66,7 @@ class CoverageTechnicalConfSchema(MongoCoverageTechnicalConfSchema, NoUnknownFie
     pass
 
 class EnvironmentSchema(MongoEnvironmentSchema, NoUnknownFieldMixin):
-    pass
+    current_ntfs_id = fields.String(allow_none=True, dump_only=True)
 
 class EnvironmentListSchema(MongoEnvironmentListSchema, NoUnknownFieldMixin):
     production = fields.Nested(EnvironmentSchema, allow_none=True)

--- a/tartare/tasks.py
+++ b/tartare/tasks.py
@@ -125,7 +125,7 @@ def send_file(self, coverage_id, environment_type, file_id):
     file = models.get_file_from_gridfs(file_id)
     logging.debug('file: %s', file)
     logger.info('trying to send %s to %s', file.filename, url)
-    #how to handle the timeout?
+    #how to handle timeout?
     response = upload_file(url, file.filename, file)
     if response.status_code != 200:
         raise self.retry()

--- a/tartare/tasks.py
+++ b/tartare/tasks.py
@@ -104,21 +104,6 @@ def handle_data(coverage):
             shutil.move(input_file, output_file)
 
 
-@celery.task(bind=True)
-def update_calendars(self, coverage_id):
-    coverage = models.Coverage.get(coverage_id)
-    input_dir = coverage.technical_conf.input_dir
-    current_data_dir = coverage.technical_conf.current_data_dir
-    output_dir = coverage.technical_conf.output_dir
-    # Merge with last NTFS
-    current_ntfs = _get_current_nfts_file(current_data_dir)
-    grid_calendars_file = coverage.get_grid_calendars()
-    if current_ntfs and grid_calendars_file:
-        output_ntfs_file = os.path.join(output_dir, '{}-database.zip'\
-                .format(datetime.datetime.now().strftime("%Y%m%d%H%M%S")))
-        logger.debug("Working to generate [{}]".format(output_ntfs_file))
-        _do_merge_calendar(grid_calendars_file, current_ntfs, output_ntfs_file)
-
 @celery.task(bind=True, default_retry_delay=300, max_retries=5, acks_late=True)
 def send_file_to_tyr_and_discard(self, coverage_id, environment_type, file_id):
     coverage = models.Coverage.get(coverage_id)

--- a/tests/integration/mongo/conftest.py
+++ b/tests/integration/mongo/conftest.py
@@ -82,5 +82,7 @@ def coverage_obj(tmpdir, get_app_context):
                                                   output_dir=str(output),
                                                   current_data_dir=str(current_dir))
     coverage = models.Coverage(id='test', name='test', technical_conf=conf)
+    coverage.environments['production'] = models.Environment(name='prod',
+                                                             tyr_url='http://tyr.prod/v0/instances/test')
     coverage.save()
     return coverage

--- a/tests/integration/mongo/coverage_data_update_api_test.py
+++ b/tests/integration/mongo/coverage_data_update_api_test.py
@@ -33,64 +33,61 @@ from glob import glob
 from tests.utils import to_json, post, patch, get_valid_ntfs_memory_archive
 from zipfile import ZipFile, ZIP_DEFLATED
 from io import BytesIO
+import requests_mock
 
 
-def test_post_pbf_returns_success_status(app, coverage):
-    filename = 'empty_pbf.osm.pbf'
-    path = os.path.join(os.path.dirname(os.path.dirname(os.path.dirname(__file__))), 'fixtures/geo_data/', filename)
+def test_post_pbf_returns_success_status(app, coverage_obj, fixture_dir):
+    path = os.path.join(fixture_dir, 'geo_data/empty_pbf.osm.pbf')
     files = {'file': (open(path, 'rb'), 'empty_pbf.osm.pbf')}
-    raw = app.post('/coverages/jdr/data_update', data=files)
+    with requests_mock.Mocker() as m:
+        m.post('http://tyr.prod/v0/instances/test', text='ok')
+        raw = app.post('/coverages/test/environments/production/data_update', data=files)
+        assert m.called
+        #TODO check the call
     r = to_json(raw)
-    input_dir = coverage['technical_conf']['input_dir']
-    assert input_dir == './input/jdr'
     assert raw.status_code == 200
     assert r.get('message').startswith('Valid osm file provided')
-    assert os.path.exists(os.path.join(input_dir, filename))
 
-def test_post_pbf_with_bad_param(app, coverage):
+def test_post_pbf_with_bad_param(app, coverage_obj, fixture_dir):
     filename = 'empty_pbf.osm.pbf'
-    path = os.path.join(os.path.dirname(os.path.dirname(os.path.dirname(__file__))), 'fixtures/geo_data/', filename)
+    path = os.path.join(fixture_dir, 'geo_data/empty_pbf.osm.pbf')
     files = {'file_name': (open(path, 'rb'), 'empty_pbf.osm.pbf')}
-    raw = app.post('/coverages/jdr/data_update', data=files)
+    raw = app.post('/coverages/test/environments/production/data_update', data=files)
     r = to_json(raw)
     assert raw.status_code == 400
     assert r.get('message') == 'file provided with bad param ("file" param expected)'
 
-def test_post_osm_returns_invalid_file_extension_message(app, coverage):
+def test_post_osm_returns_invalid_file_extension_message(app, coverage_obj, fixture_dir):
     filename = 'empty_pbf.funky_extension'
-    path = os.path.join(os.path.dirname(os.path.dirname(os.path.dirname(__file__))), 'fixtures/geo_data/', filename)
+    path = os.path.join(fixture_dir, 'geo_data/empty_pbf.funky_extension')
     files = {'file': (open(path, 'rb'), 'empty_pbf.funky_extension')}
-    raw = app.post('/coverages/jdr/data_update', data=files)
+    raw = app.post('/coverages/test/environments/production/data_update', data=files)
     r = to_json(raw)
     assert raw.status_code == 400
     assert r.get('message').startswith('invalid file provided')
 
-def test_post_osm_returns_invalid_coverage(app, coverage):
-    filename = 'empty_pbf.osm.pbf'
-    path = os.path.join(os.path.dirname(os.path.dirname(os.path.dirname(__file__))), 'fixtures/geo_data/', filename)
+def test_post_osm_returns_invalid_coverage(app, fixture_dir):
+    path = os.path.join(fixture_dir, 'geo_data/empty_pbf.osm.pbf')
     files = {'file': (open(path, 'rb'), 'empty_pbf.funky_extension')}
-    raw = app.post('/coverages/jdr_bug/data_update', data=files)
+    raw = app.post('/coverages/jdr_bug/environments/production/data_update', data=files)
     r = to_json(raw)
     assert raw.status_code == 404
     assert r.get('message') == 'bad coverage jdr_bug'
 
-def test_post_pbf_returns_file_missing_message(app, coverage):
-    raw = app.post('/coverages/jdr/data_update')
+def test_post_pbf_returns_file_missing_message(app, coverage_obj):
+    raw = app.post('/coverages/test/environments/production/data_update')
     r = to_json(raw)
     assert raw.status_code == 400
-    print("--------------")
-    print(r.get('message'))
     assert r.get('message') == 'no file provided'
 
-def test_post_ntfs_success(tmpdir, app, coverage):
+def test_post_ntfs_success(app, coverage_obj):
     #create ZIP file with fixture before sending it
-    input = tmpdir.mkdir('input')
     with get_valid_ntfs_memory_archive() as (ntfs_file_name, ntfs_zip_memory):
         files = {'file': (ntfs_zip_memory, ntfs_file_name)}
-        raw = app.post('/coverages/jdr/data_update', data=files)
+        with requests_mock.Mocker() as m:
+            m.post('http://tyr.prod/v0/instances/test', text='ok')
+            raw = app.post('/coverages/test/environments/production/data_update', data=files)
+            assert m.called
         r = to_json(raw)
-        input_dir = coverage['technical_conf']['input_dir']
-        assert input_dir == './input/jdr'
         assert raw.status_code == 200
         assert r.get('message').startswith('Valid fusio file provided')
-        assert os.path.exists(os.path.join(input_dir, ntfs_file_name))

--- a/tests/integration/mongo/coverage_data_update_api_test.py
+++ b/tests/integration/mongo/coverage_data_update_api_test.py
@@ -43,7 +43,6 @@ def test_post_pbf_returns_success_status(app, coverage_obj, fixture_dir):
         m.post('http://tyr.prod/v0/instances/test', text='ok')
         raw = app.post('/coverages/test/environments/production/data_update', data=files)
         assert m.called
-        #TODO check the call
     r = to_json(raw)
     assert raw.status_code == 200
     assert r.get('message').startswith('Valid osm file provided')

--- a/tests/integration/mongo/update_data_test.py
+++ b/tests/integration/mongo/update_data_test.py
@@ -2,7 +2,7 @@ import os
 from glob import glob
 from shutil import copy
 from zipfile import ZipFile, ZIP_DEFLATED
-from tartare.tasks import handle_data, update_calendars, send_file
+from tartare.tasks import handle_data, send_file_to_tyr_and_discard
 from tartare.core import calendar_handler, models
 import requests_mock
 
@@ -64,56 +64,11 @@ def test_handle_ntfs_data_with_calendar(coverage_obj, fixture_dir):
         assert calendar_handler.GRID_CALENDAR_REL_LINE in files_in_zip
 
 
-def test_update_calendars_without_ntfs(coverage_obj, fixture_dir):
-    """
-    Test if a calendar file is in input_dir and there is no ntfs file
-    in current_dir.
-    calendar is moved to current_dir/grid_calendar
-    """
-    calendar_file = os.path.join(fixture_dir, 'gridcalendar/export_calendars.zip')
-
-    with open(calendar_file, 'rb') as f:
-        coverage_obj.save_grid_calendars(f)
-
-    update_calendars(coverage_obj.id)
-
-    #nothing happens we don't have base data
-    assert os.listdir(coverage_obj.technical_conf.output_dir) == []
-
-
-def test_update_calendar_data_with_last_ntfs(coverage_obj, fixture_dir):
-    """
-    Test if a calendar file is in input_dir and there is a ntfs file
-    in current_dir.llir/grid_calendar and merged with the ntfs file
-    and the result is moved to output_dir
-    """
-    calendar_file = os.path.join(fixture_dir, 'gridcalendar/export_calendars.zip')
-    ntfs_path = os.path.join(fixture_dir, 'ntfs/*.txt')
-
-    ntfs_zip = ZipFile(os.path.join(coverage_obj.technical_conf.current_data_dir, 'ntfs.zip'), 'a', ZIP_DEFLATED, False)
-    for filename in glob(ntfs_path):
-        ntfs_zip.write(filename, os.path.basename(filename))
-    ntfs_zip.close()
-
-    with open(calendar_file, 'rb') as f:
-        coverage_obj.save_grid_calendars(f)
-    update_calendars(coverage_obj.id)
-
-    files_in_output_dir = os.listdir(coverage_obj.technical_conf.output_dir)
-
-    assert files_in_output_dir[0].endswith('database.zip')
-
-    with ZipFile(os.path.join(coverage_obj.technical_conf.output_dir, files_in_output_dir[0])) as new_ntfs_zip:
-        files_in_zip = new_ntfs_zip.namelist()
-        assert calendar_handler.GRID_CALENDARS in files_in_zip
-        assert calendar_handler.GRID_PERIODS in files_in_zip
-        assert calendar_handler.GRID_CALENDAR_REL_LINE in files_in_zip
-
 def test_upload_file_ok(coverage_obj, fixture_dir):
     path = os.path.join(fixture_dir, 'geo_data/empty_pbf.osm.pbf')
     with open(path, 'rb') as f:
         file_id = models.save_file_in_gridfs(f, filename='test.osm.pbf')
     with requests_mock.Mocker() as m:
         m.post('http://tyr.prod/v0/instances/test', text='ok')
-        send_file(coverage_obj.id, 'production', file_id)
+        send_file_to_tyr_and_discard(coverage_obj.id, 'production', file_id)
         assert m.called


### PR DESCRIPTION
All data are now stored in mongo via gridfs.
background task for moving file has been kept for compatibility and should be removed when data will be published by POST only.


TODO:
 - [ ] add tests on new tasks
 - [ ] handle timeout
 - [x] migrate handling of calendar with ntfs from gridfs