### PR TITLE
temporary fix to upload problems

### DIFF
--- a/tartare/helper.py
+++ b/tartare/helper.py
@@ -42,11 +42,13 @@ def grid_out_len(self):
 GridOut.__len__ = grid_out_len
 
 def upload_file(url, filename, file):
-    form = encoder.MultipartEncoder({
-        'file': (filename, file, 'application/octet-stream')
-    })
-    headers =  {'Content-Type': form.content_type}
-    return requests.post(url, headers=headers, data=form)
+    return requests.post(url, files={'file': file}, timeout=120)
+    #TODO: fix interaction between toolbets and gridfs file
+    #form = encoder.MultipartEncoder({
+    #    'file': (filename, file, 'application/octet-stream')
+    #})
+    #headers =  {'Content-Type': form.content_type}
+    #return requests.post(url, headers=headers, data=form, timeout=10)
 
 
 def configure_logger(app_config):

--- a/tartare/tasks.py
+++ b/tartare/tasks.py
@@ -112,11 +112,14 @@ def send_file_to_tyr_and_discard(self, coverage_id, environment_type, file_id):
     logging.debug('file: %s', file)
     logger.info('trying to send %s to %s', file.filename, url)
     #TODO: how to handle timeout?
-    response = upload_file(url, file.filename, file)
-    if response.status_code != 200:
-        raise self.retry()
-    else:
-        models.delete_file_from_gridfs(file_id)
+    try:
+        response = upload_file(url, file.filename, file)
+        if response.status_code != 200:
+            raise self.retry()
+        else:
+            models.delete_file_from_gridfs(file_id)
+    except:
+        logging.exception('error')
 
 @celery.task(bind=True, default_retry_delay=300, max_retries=5, acks_late=True)
 def send_ntfs_to_tyr(self, coverage_id, environment_type):


### PR DESCRIPTION
gridfs files and requests_toolbets seems to not mix well: they are
blocking :(

toolbets is used for streaming upload, so we will need it for big files