### PR TITLE
Export port 5000 for webservice

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -50,5 +50,6 @@ USER tartare
 # you can pass a TARTARE_VERSION to the build (with cli argument --build-arg or in docker-compose)
 ARG TARTARE_VERSION
 ENV TARTARE_VERSION ${TARTARE_VERSION:-unknown_version}
+EXPOSE 5000
 
 CMD ["celery", "-A", "tartare.tasks.celery", "worker"]


### PR DESCRIPTION
We need to force the exposition of the port for it to work with the
nginx reverse proxy on docker swarmo
We should probaly create two images, but first this will do the job.