### PR TITLE
Adding a NTFS download API to speed-up data analyse

### DIFF
--- a/tartare/api.py
+++ b/tartare/api.py
@@ -36,7 +36,7 @@ from tartare.interfaces.index import Index
 from tartare.interfaces.coverages import Coverage
 from tartare.interfaces.contributors import Contributor
 from tartare.interfaces.grid_calendar import GridCalendar
-from tartare.interfaces.data_update import DataUpdate
+from tartare.interfaces.data_update import DataUpdate, CoverageData
 
 
 api = Api(app)
@@ -48,4 +48,6 @@ api.add_resource(Coverage, '/coverages', '/coverages/', '/coverages/<string:cove
 api.add_resource(GridCalendar, '/coverages/<string:coverage_id>/grid_calendar', endpoint='grid_calendar')
 api.add_resource(DataUpdate, '/coverages/<string:coverage_id>/environments/<string:environment_type>/data_update',
                              endpoint='data_update')
+api.add_resource(CoverageData, '/coverages/<string:coverage_id>/environments/<string:environment_type>/data/<string:data_type>',
+                             endpoint='data')
 api.add_resource(Contributor, '/contributors', '/contributors/', '/contributors/<string:contributor_id>', endpoint='contributors')

--- a/tartare/interfaces/contributors.py
+++ b/tartare/interfaces/contributors.py
@@ -49,10 +49,13 @@ class Contributor(flask_restful.Resource):
         try:
             contributor.save()
         except DuplicateKeyError as e:
-            logging.getLogger(__name__).exception('impossible to add contributor {}, data_prefix already used ({})'.format(contributor, request.json['data_prefix']))
+            logging.getLogger(__name__).exception(
+                'impossible to add contributor {}, data_prefix already used ({})'.format(
+                    contributor, request.json['data_prefix']))
             return {'error': str(e)}, 400
         except PyMongoError as e:
-            logging.getLogger(__name__).exception('impossible to add contributor {}'.format(contributor))
+            logging.getLogger(__name__).exception(
+                'impossible to add contributor {}'.format(contributor))
             return {'error': str(e)}, 500
 
         return {'contributor': contributor_schema.dump(contributor).data}, 201
@@ -74,7 +77,8 @@ class Contributor(flask_restful.Resource):
         return {'contributor': None}, 204
 
     def patch(self, contributor_id):
-        # "data_prefix" field is not modifiable, impacts of the modification need to be checked. The previous value needs to be checked for an error
+        # "data_prefix" field is not modifiable, impacts of the modification
+        # need to be checked. The previous value needs to be checked for an error
         contributor = models.Contributor.get(contributor_id)
         if contributor is None:
             abort(404)
@@ -85,14 +89,16 @@ class Contributor(flask_restful.Resource):
             return {'error': errors}, 400
 
         if 'data_prefix' in request.json and contributor.data_prefix != request.json['data_prefix']:
-            return {'error': 'The modification of the data_prefix is not possible ({} => {})'.format(contributor.data_prefix, request.json['data_prefix'])}, 400
+            return {'error': 'The modification of the data_prefix is not possible ({} => {})'.format(
+                contributor.data_prefix, request.json['data_prefix'])}, 400
         if 'id' in request.json and contributor.id != request.json['id']:
             return {'error': 'The modification of the id is not possible'}, 400
 
         try:
             contributor = models.Contributor.update(contributor_id, request.json)
         except PyMongoError as e:
-            logging.getLogger(__name__).exception('impossible to update contributor with dataset {}'.format(args))
+            logging.getLogger(__name__).exception(
+                'impossible to update contributor with dataset {}'.format(args))
             return {'error': str(e)}, 500
 
         return {'contributor': schema.ContributorSchema().dump(contributor).data}, 200

--- a/tartare/interfaces/data_update.py
+++ b/tartare/interfaces/data_update.py
@@ -85,7 +85,7 @@ class CoverageData(Resource):
 
     def get(self, coverage_id, environment_type, data_type):
         if data_type != 'ntfs':
-            return {'message': 'bad data type {}'.format(data_type)}, 404
+            return {'message': 'bad data type {} ("ntfs" expected)'.format(data_type)}, 404
         coverage = models.Coverage.get(coverage_id)
         if coverage is None:
             return {'message': 'bad coverage {}'.format(coverage_id)}, 404

--- a/tartare/interfaces/data_update.py
+++ b/tartare/interfaces/data_update.py
@@ -41,43 +41,51 @@ import shutil
 from tartare import tasks
 
 
+def add_coverage_data(coverage_id, coverage, environment_type):
+    if coverage is None:
+        return {'message': 'bad coverage {}'.format(coverage_id)}, 404
+
+    if environment_type not in coverage.environments:
+        return {'message': 'bad environment {}'.format(environment_type)}, 404
+
+    if not request.files :
+        return {'message': 'no file provided'}, 400
+    if request.files and 'file' not in request.files:
+        return {'message': 'file provided with bad param ("file" param expected)'}, 400
+    content = request.files['file']
+    logger = logging.getLogger(__name__)
+    logger.info('content received: %s', content)
+    with tempfile.TemporaryDirectory() as tmpdirname:
+        tmp_file = os.path.join(tmpdirname, content.filename)
+        content.save(tmp_file)
+        #TODO: improve this function so we don't have to write the file localy first
+        file_type, file_name = data_handler.type_of_data(tmp_file)
+        if file_type in [None, "tmp"] :
+            logger.warning('invalid file provided: %s', content.filename)
+            return {'message': 'invalid file provided: {}'.format(content.filename)}, 400
+        with open(tmp_file, 'rb') as file:
+            if file_type == 'fusio': #ntfs is called fusio in type_of_data
+                coverage.save_ntfs(environment_type, file)
+                tasks.send_ntfs_to_tyr.delay(coverage_id, environment_type)
+            else:
+                #we need to temporary save the file before sending it
+                file_id = models.save_file_in_gridfs(file, filename=content.filename)
+                tasks.send_file_to_tyr_and_discard.delay(coverage_id, environment_type, file_id)
+    return {'message': 'Valid {} file provided : {}'.format(file_type, file_name)}, 200
+
 class DataUpdate(Resource):
     def post(self, coverage_id, environment_type):
         coverage = models.Coverage.get(coverage_id)
-        if coverage is None:
-            return {'message': 'bad coverage {}'.format(coverage_id)}, 404
+        return add_coverage_data(coverage_id, coverage, environment_type)
 
-        if environment_type not in coverage.environments:
-            return {'message': 'bad environment {}'.format(environment_type)}, 404
+class CoverageData(Resource):
+    def post(self, coverage_id, environment_type, data_type=None):
+        coverage = models.Coverage.get(coverage_id)
+        return add_coverage_data(coverage, environment_type)
 
-        if not request.files :
-            return {'message': 'no file provided'}, 400
-        if request.files and 'file' not in request.files:
-            return {'message': 'file provided with bad param ("file" param expected)'}, 400
-        content = request.files['file']
-        logger = logging.getLogger(__name__)
-        logger.info('content received: %s', content)
-        with tempfile.TemporaryDirectory() as tmpdirname:
-            tmp_file = os.path.join(tmpdirname, content.filename)
-            content.save(tmp_file)
-
-            #TODO: improve this function so we don't have to write the file localy first
-            file_type, file_name = data_handler.type_of_data(tmp_file)
-            if file_type in [None, "tmp"] :
-                logger.warning('invalid file provided: %s', content.filename)
-                return {'message': 'invalid file provided: {}'.format(content.filename)}, 400
-            with open(tmp_file, 'rb') as file:
-                if file_type == 'fusio': #ntfs is called fusio in type_of_data
-                    coverage.save_ntfs(environment_type, file)
-                    tasks.send_ntfs_to_tyr.delay(coverage_id, environment_type)
-                else:
-                    #we need to temporary save the file before sending it
-                    file_id = models.save_file_in_gridfs(file, filename=content.filename)
-                    tasks.send_file_to_tyr_and_discard.delay(coverage_id, environment_type, file_id)
-
-        return {'message': 'Valid {} file provided : {}'.format(file_type, file_name)}, 200
-
-    def get(self, coverage_id, environment_type):
+    def get(self, coverage_id, environment_type, data_type):
+        if data_type != 'ntfs':
+            return {'message': 'bad data type {}'.format(data_type)}, 404
         coverage = models.Coverage.get(coverage_id)
         if coverage is None:
             return {'message': 'bad coverage {}'.format(coverage_id)}, 404

--- a/tartare/interfaces/data_update.py
+++ b/tartare/interfaces/data_update.py
@@ -84,8 +84,10 @@ class CoverageData(Resource):
         return add_coverage_data(coverage, environment_type)
 
     def get(self, coverage_id, environment_type, data_type):
-        if data_type != 'ntfs':
-            return {'message': 'bad data type {} ("ntfs" expected)'.format(data_type)}, 404
+        available_data_types = ['ntfs']
+        if data_type.lower() not in available_data_types:
+            return {'message': 'bad data type {} (expected formats: {})'.format(
+                data_type, ','.join(available_data_types))}, 404
         coverage = models.Coverage.get(coverage_id)
         if coverage is None:
             return {'message': 'bad coverage {}'.format(coverage_id)}, 404

--- a/tests/integration/mongo/update_data_test.py
+++ b/tests/integration/mongo/update_data_test.py
@@ -35,3 +35,17 @@ def test_get_ntfs_file_ok(app, coverage_obj, fixture_dir):
             ntfs_zip = ZipFile(ntfs_zip_memory, 'r', ZIP_DEFLATED, False)
             assert ntfs_zip.testzip() is None
             ntfs_zip.close()
+
+
+def test_get_ntfs_bad_requedted_type(app, coverage_obj, fixture_dir):
+    with get_valid_ntfs_memory_archive() as (ntfs_file_name, ntfs_zip_memory):
+        files = {'file': (ntfs_zip_memory, ntfs_file_name)}
+        with requests_mock.Mocker() as m:
+            m.post('http://tyr.prod/v0/instances/test', text='ok')
+            raw = app.post('/coverages/test/environments/production/data_update', data=files)
+        r = to_json(raw)
+        assert r['message'].startswith('Valid fusio file provided')
+        raw = app.get('/coverages/test/environments/production/data/ntfs_error')
+        r = to_json(raw)
+        assert raw.status_code == 404
+        assert r["message"].startswith('bad data type')

--- a/tests/integration/mongo/update_data_test.py
+++ b/tests/integration/mongo/update_data_test.py
@@ -48,4 +48,5 @@ def test_get_ntfs_bad_requedted_type(app, coverage_obj, fixture_dir):
         raw = app.get('/coverages/test/environments/production/data/ntfs_error')
         r = to_json(raw)
         assert raw.status_code == 404
+        print(r["message"])
         assert r["message"].startswith('bad data type')

--- a/tests/integration/mongo/update_data_test.py
+++ b/tests/integration/mongo/update_data_test.py
@@ -18,6 +18,7 @@ def test_upload_file_ok(coverage_obj, fixture_dir):
         send_file_to_tyr_and_discard(coverage_obj.id, 'production', file_id)
         assert m.called
 
+
 def test_get_ntfs_file_ok(app, coverage_obj, fixture_dir):
     with get_valid_ntfs_memory_archive() as (ntfs_file_name, ntfs_zip_memory):
         files = {'file': (ntfs_zip_memory, ntfs_file_name)}
@@ -26,7 +27,7 @@ def test_get_ntfs_file_ok(app, coverage_obj, fixture_dir):
             raw = app.post('/coverages/test/environments/production/data_update', data=files)
         r = to_json(raw)
         assert r['message'].startswith('Valid fusio file provided')
-        raw = app.get('/coverages/test/environments/production/data_update')
+        raw = app.get('/coverages/test/environments/production/data/ntfs')
         assert raw.status_code == 200
         assert raw.mimetype == 'application/zip'
         data = raw.get_data()

--- a/tests/integration/mongo/update_data_test.py
+++ b/tests/integration/mongo/update_data_test.py
@@ -2,6 +2,12 @@ import os
 from tartare.tasks import send_file_to_tyr_and_discard
 from tartare.core import models
 import requests_mock
+import logging
+from tests.utils import to_json, get_valid_ntfs_memory_archive
+
+from io import BytesIO
+from zipfile import ZipFile, ZIP_DEFLATED
+
 
 def test_upload_file_ok(coverage_obj, fixture_dir):
     path = os.path.join(fixture_dir, 'geo_data/empty_pbf.osm.pbf')
@@ -11,3 +17,20 @@ def test_upload_file_ok(coverage_obj, fixture_dir):
         m.post('http://tyr.prod/v0/instances/test', text='ok')
         send_file_to_tyr_and_discard(coverage_obj.id, 'production', file_id)
         assert m.called
+
+def test_get_ntfs_file_ok(app, coverage_obj, fixture_dir):
+    with get_valid_ntfs_memory_archive() as (ntfs_file_name, ntfs_zip_memory):
+        files = {'file': (ntfs_zip_memory, ntfs_file_name)}
+        with requests_mock.Mocker() as m:
+            m.post('http://tyr.prod/v0/instances/test', text='ok')
+            raw = app.post('/coverages/test/environments/production/data_update', data=files)
+        r = to_json(raw)
+        assert r['message'].startswith('Valid fusio file provided')
+        raw = app.get('/coverages/test/environments/production/data_update')
+        assert raw.status_code == 200
+        assert raw.mimetype == 'application/zip'
+        data = raw.get_data()
+        with BytesIO(data) as ntfs_zip_memory:
+            ntfs_zip = ZipFile(ntfs_zip_memory, 'r', ZIP_DEFLATED, False)
+            assert ntfs_zip.testzip() is None
+            ntfs_zip.close()


### PR DESCRIPTION
There was only a POST API in `/coverages/<string:coverage_id>/environments/<string:environment_type>/data_update` so I added a GET API on the same end_point.