### PR TITLE
Add datasource to coverage

### DIFF
--- a/documentation/openAPI.yaml
+++ b/documentation/openAPI.yaml
@@ -164,6 +164,37 @@ paths:
           schema:
             $ref: '#/definitions/message'
 
+  /coverages/{coverage_id}/data_sources:
+    post:
+      summary: Add a data_source to coverage <coverage_id>
+      tags:
+        - coverages
+      consumes:
+        - multipart/form-data
+      produces:
+        - application/json
+      parameters:
+        - in: path
+          name: coverage_id
+          type: string
+          description: Identifier of the coverage that needs to be modified
+          required: true
+        - in: body
+          name: body
+          description: data_source id that you want to add to the coverage
+          required: true
+          schema:
+            $ref: "#/definitions/data_source_id"
+      responses:
+        200:
+          description: Data source added
+          schema:
+            $ref: "#/definitions/coverage"
+        400:
+          description: Error
+          schema:
+            $ref: '#/definitions/error'
+
   /coverages/{coverage_id}/environments/{environment_type}/data/{data_type}:
     get:
       summary: Retrieve the latest data file of the specified coverage
@@ -410,6 +441,13 @@ definitions:
         example: 5810cb2d3c96b7000108d074
       environments:
         $ref: "#/definitions/environments"
+
+  data_source_id:
+    type: object
+    properties:
+      data_source_id:
+        type: string
+        example: 5810cb2d3c96b7000108d074
 
   environments:
     type: object

--- a/documentation/openAPI.yaml
+++ b/documentation/openAPI.yaml
@@ -60,10 +60,7 @@ paths:
         200:
           description: Array of coverages
           schema:
-            title: coverages
-            type: array
-            items:
-              $ref: '#/definitions/coverage'
+            $ref: '#/definitions/coverages'
 
     post:
       summary: Create a new coverage
@@ -84,7 +81,7 @@ paths:
         200:
           description: Created coverage
           schema:
-            $ref: "#/definitions/coverage"
+            $ref: "#/definitions/coverages"
 
   /coverages/{coverage_id}:
     patch:
@@ -111,7 +108,7 @@ paths:
         200:
           description: Modified coverage
           schema:
-            $ref: "#/definitions/coverage"
+            $ref: "#/definitions/coverages"
         400:
           description: Error in provided data
           schema:
@@ -170,7 +167,7 @@ paths:
       tags:
         - coverages
       consumes:
-        - multipart/form-data
+        - application/json
       produces:
         - application/json
       parameters:
@@ -189,7 +186,7 @@ paths:
         200:
           description: Data source added
           schema:
-            $ref: "#/definitions/coverage"
+            $ref: "#/definitions/coverages"
         400:
           description: Error
           schema:
@@ -426,6 +423,13 @@ paths:
 
 
 definitions:
+  coverages:
+    type: object
+    properties:
+      coverages:
+        type: array
+        items:
+          $ref: "#/definitions/coverage"
 
   coverage:
     type: object
@@ -445,7 +449,7 @@ definitions:
   data_source_id:
     type: object
     properties:
-      data_source_id:
+      id:
         type: string
         example: 5810cb2d3c96b7000108d074
 

--- a/documentation/openAPI.yaml
+++ b/documentation/openAPI.yaml
@@ -193,7 +193,7 @@ paths:
         400:
           description: Error
           schema:
-            $ref: '#/definitions/error'
+            $ref: '#/definitions/message'
 
   /coverages/{coverage_id}/environments/{environment_type}/data/{data_type}:
     get:

--- a/tartare/api.py
+++ b/tartare/api.py
@@ -38,6 +38,7 @@ from tartare.interfaces.contributors import Contributor
 from tartare.interfaces.grid_calendar import GridCalendar
 from tartare.interfaces.data_update import DataUpdate, CoverageData
 from tartare.interfaces.data_sources import DataSource
+from tartare.interfaces.coverage_data_source_subscription import CoverageDataSourceSubscription
 
 
 api = Api(app)
@@ -53,3 +54,4 @@ api.add_resource(CoverageData, '/coverages/<string:coverage_id>/environments/<st
                              endpoint='data')
 api.add_resource(Contributor, '/contributors', '/contributors/', '/contributors/<string:contributor_id>', endpoint='contributors')
 api.add_resource(DataSource, '/contributors/<string:contributor_id>/data_sources', '/contributors/<string:contributor_id>/data_sources/<string:data_source_id>')
+api.add_resource(CoverageDataSourceSubscription, '/coverages/<string:coverage_id>/data_sources', '/coverages/<string:coverage_id>/data_sources/<string:data_source_id>', endpoint='coverages_data_sources')

--- a/tartare/helper.py
+++ b/tartare/helper.py
@@ -84,16 +84,21 @@ def make_celery(app):
 def _make_doted_key(*args):
     return '.'.join([e for e in args if e])
 
+
 def to_doted_notation(data, prefix=None):
     result = {}
-    for k,v in data.items():
+    for k, v in data.items():
         key = _make_doted_key(prefix, k)
         if isinstance(v, Mapping):
             result.update(to_doted_notation(v, key))
         elif isinstance(v, list):
-            for lk, lv in enumerate(v):
-                list_key = _make_doted_key(key, str(lk))
-                result.update(to_doted_notation(lv, list_key))
+            # if data is a list of scalars
+            if all(isinstance(item, (int, float, str, bool)) for item in v):
+                result[key] = v
+            else:
+                for lk, lv in enumerate(v):
+                    list_key = _make_doted_key(key, str(lk))
+                    result.update(to_doted_notation(lv, list_key))
         else:
             result[key] = v
     return result

--- a/tartare/interfaces/coverage_data_source_subscription.py
+++ b/tartare/interfaces/coverage_data_source_subscription.py
@@ -1,0 +1,67 @@
+# Copyright (c) 2001-2016, Canal TP and/or its affiliates. All rights reserved.
+#
+# This file is part of Navitia,
+#     the software to build cool stuff with public transport.
+#
+# Hope you'll enjoy and contribute to this project,
+#     powered by Canal TP (www.canaltp.fr).
+# Help us simplify mobility and open public transport:
+#     a non ending quest to the responsive locomotion way of traveling!
+#
+# LICENCE: This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+# Stay tuned using
+# twitter @navitia
+# IRC #navitia on freenode
+# https://groups.google.com/d/forum/navitia
+# www.navitia.io
+
+from flask_restful import request
+import flask_restful
+from pymongo.errors import PyMongoError
+from tartare.core import models
+import logging
+from tartare.interfaces import schema
+
+
+class CoverageDataSourceSubscription(flask_restful.Resource):
+    def post(self, coverage_id):
+        coverage = models.Coverage.get(coverage_id)
+        if coverage is None:
+            return {'message': 'bad coverage {}'.format(coverage_id)}, 400
+
+        if 'id' not in request.json:
+            return {'error': 'Missing data_source_id attribute in request body.'}, 400
+
+        data_source_id = request.json['id']
+
+        try:
+            data_sources = models.DataSource.get(data_source_id=data_source_id)
+        except ValueError:
+            return {'error': 'unknown data_source_id {}.'.format(data_source_id, coverage_id)}, 400
+
+        if coverage.has_data_source(data_sources[0]):
+            return {'error': 'data_source_id {} already exists in coverage {}.'.format(data_source_id, coverage_id)}, 400
+
+        coverage.add_data_source(data_sources[0])
+
+        try:
+            coverage = models.Coverage.update(coverage_id, {"data_sources": coverage.data_sources})
+        except (PyMongoError, ValueError) as e:
+            logging.getLogger(__name__).exception(
+                'impossible to update coverage {} with data_source {}'.format(coverage_id, data_source_id)
+            )
+            return {'error': str(e)}, 400
+
+        return {'coverages': schema.CoverageSchema().dump([coverage], many=True).data}, 200

--- a/tartare/interfaces/coverage_data_source_subscription.py
+++ b/tartare/interfaces/coverage_data_source_subscription.py
@@ -39,20 +39,20 @@ class CoverageDataSourceSubscription(flask_restful.Resource):
     def post(self, coverage_id):
         coverage = models.Coverage.get(coverage_id)
         if coverage is None:
-            return {'message': 'bad coverage {}'.format(coverage_id)}, 400
+            return {'message': 'Bad coverage {}.'.format(coverage_id)}, 400
 
         if 'id' not in request.json:
-            return {'error': 'Missing data_source_id attribute in request body.'}, 400
+            return {'message': 'Missing data_source_id attribute in request body.'}, 400
 
         data_source_id = request.json['id']
 
         try:
             data_sources = models.DataSource.get(data_source_id=data_source_id)
         except ValueError:
-            return {'error': 'unknown data_source_id {}.'.format(data_source_id, coverage_id)}, 400
+            return {'message': 'Unknown data_source_id {}.'.format(data_source_id, coverage_id)}, 400
 
         if coverage.has_data_source(data_sources[0]):
-            return {'error': 'data_source_id {} already exists in coverage {}.'.format(data_source_id, coverage_id)}, 400
+            return {'message': 'Data source id {} already exists in coverage {}.'.format(data_source_id, coverage_id)}, 400
 
         coverage.add_data_source(data_sources[0])
 
@@ -62,6 +62,6 @@ class CoverageDataSourceSubscription(flask_restful.Resource):
             logging.getLogger(__name__).exception(
                 'impossible to update coverage {} with data_source {}'.format(coverage_id, data_source_id)
             )
-            return {'error': str(e)}, 400
+            return {'message': str(e)}, 400
 
         return {'coverages': schema.CoverageSchema().dump([coverage], many=True).data}, 200

--- a/tartare/interfaces/coverages.py
+++ b/tartare/interfaces/coverages.py
@@ -70,7 +70,7 @@ class Coverage(flask_restful.Resource):
         c = models.Coverage.delete(coverage_id)
         if c == 0:
             abort(404)
-        return {'coverage': None}, 204
+        return "", 204
 
     def patch(self, coverage_id):
         coverage = models.Coverage.get(coverage_id)

--- a/tartare/interfaces/coverages.py
+++ b/tartare/interfaces/coverages.py
@@ -51,7 +51,7 @@ class Coverage(flask_restful.Resource):
             logging.getLogger(__name__).exception('impossible to add coverage {}'.format(coverage))
             return {'error': str(e)}, 500
 
-        return {'coverage': coverage_schema.dump(coverage).data}, 201
+        return {'coverages': coverage_schema.dump([coverage], many=True).data}, 201
 
     def get(self, coverage_id=None):
         if coverage_id:
@@ -60,7 +60,7 @@ class Coverage(flask_restful.Resource):
                 abort(404)
 
             result = schema.CoverageSchema().dump(c)
-            return {'coverage': result.data}, 200
+            return {'coverages': [result.data]}, 200
 
         coverages = models.Coverage.all()
 
@@ -90,4 +90,4 @@ class Coverage(flask_restful.Resource):
             logging.getLogger(__name__).exception('impossible to update coverage with dataset {}'.format(request.json))
             return {'error': str(e)}, 500
 
-        return {'coverage': schema.CoverageSchema().dump(coverage).data}, 200
+        return {'coverages': schema.CoverageSchema().dump([coverage], many=True).data}, 200

--- a/tartare/interfaces/data_sources.py
+++ b/tartare/interfaces/data_sources.py
@@ -31,7 +31,6 @@ import os
 from flask_restful import reqparse, abort, request
 import flask_restful
 from pymongo.errors import PyMongoError
-from tartare import app
 from tartare.core import models
 import logging
 from tartare.interfaces import schema

--- a/tests/helper_test.py
+++ b/tests/helper_test.py
@@ -51,6 +51,10 @@ def test_to_doted_notation_array():
     data = {'a': [{'b':1}, {'c':2}]}
     assert to_doted_notation(data) == {'a.0.b': 1, 'a.1.c':2}
 
+def test_to_doted_notation_with_list_of_scalars():
+    data = {'a': 1, 'b': {'a': 3, 'b': {'c': 9, 'd': 10}}, 'e': [1, 2.6, "bar", True]}
+    assert to_doted_notation(data) == {'a': 1, 'b.a': 3, 'b.b.c': 9, 'b.b.d': 10, 'e': [1, 2.6, "bar", True]}
+
 def test_make_doted_key():
     assert _make_doted_key('a') == 'a'
     assert _make_doted_key('a', 'b') == 'a.b'

--- a/tests/integration/mongo/conftest.py
+++ b/tests/integration/mongo/conftest.py
@@ -71,7 +71,22 @@ def coverage(app):
     coverage = app.post('/coverages',
                 headers={'Content-Type': 'application/json'},
                data='{"id": "jdr", "name": "name of the coverage jdr"}')
-    return to_json(coverage)['coverage']
+    return to_json(coverage)['coverages'][0]
+
+
+@pytest.fixture(scope="function")
+def contributor(app):
+    contributor = app.post('/contributors',
+                           headers={'Content-Type': 'application/json'},
+                           data='{"id": "bob", "name": "bob", "data_prefix": "bob"}')
+    return to_json(contributor)['contributor']
+
+@pytest.fixture(scope="function")
+def data_source(app, contributor):
+    data_source = app.post('/contributors/{}/data_sources'.format(contributor.get('id')),
+                           headers={'Content-Type': 'application/json'},
+                           data='{"name": "bobette", "data_format": "gtfs"}')
+    return to_json(data_source)['data_sources'][0]
 
 @pytest.fixture(scope="function")
 def coverage_obj(tmpdir, get_app_context):

--- a/tests/integration/mongo/coverage_api_test.py
+++ b/tests/integration/mongo/coverage_api_test.py
@@ -177,8 +177,8 @@ def test_patch_simple_coverage(app):
     raw = patch(app, '/coverages/id_test', '{"name": "new name"}')
     assert raw.status_code == 200
     r = to_json(raw)
-    assert r["coverage"]["id"] == "id_test"
-    assert r["coverage"]["name"] == "new name"
+    assert r["coverages"][0]["id"] == "id_test"
+    assert r["coverages"][0]["name"] == "new name"
 
 
 def test_delete_coverage_returns_success(app):
@@ -207,8 +207,8 @@ def test_update_coverage_returns_success_status(app):
     r = to_json(raw)
 
     assert raw.status_code == 200
-    assert r["coverage"]['id'] == "id_test"
-    assert r["coverage"]['name'] == "new_name_test"
+    assert r["coverages"][0]['id'] == "id_test"
+    assert r["coverages"][0]['name'] == "new_name_test"
 
 
 def test_update_unknown_coverage(app):

--- a/tests/integration/mongo/coverage_api_test.py
+++ b/tests/integration/mongo/coverage_api_test.py
@@ -119,7 +119,7 @@ def test_add_coverage_with_no_env(app):
     raw = post(app, '/coverages',
             '''{"id": "id_test", "name": "name of the coverage",
                 "environments" : {"notvalidenv": {"name": "pre", "tyr_url": "http://foo.bar/"}}}''')
-    print(raw.data)
+
     assert raw.status_code == 400
     r = to_json(raw)
     assert 'error' in r
@@ -129,7 +129,7 @@ def test_add_coverage_with_env_invalid_url(app):
     raw = post(app, '/coverages',
             '''{"id": "id_test", "name": "name of the coverage",
                 "environments" : {"notvalidenv": {"name": "pre", "tyr_url": "foo"}}}''')
-    print(raw.data)
+
     assert raw.status_code == 400
     r = to_json(raw)
     assert 'error' in r
@@ -258,7 +258,7 @@ def test_update_coverage__env(app):
                     "preproduction": {"name": "pre", "tyr_url": "http://pre.bar/"},
                     "production": null
                 }}''')
-    print(raw.data)
+
     assert raw.status_code == 200
     raw = app.get('/coverages')
     r = to_json(raw)

--- a/tests/integration/mongo/coverage_data_source_subscription_test.py
+++ b/tests/integration/mongo/coverage_data_source_subscription_test.py
@@ -1,0 +1,74 @@
+# coding=utf-8
+
+# Copyright (c) 2001-2016, Canal TP and/or its affiliates. All rights reserved.
+#
+# This file is part of Navitia,
+#     the software to build cool stuff with public transport.
+#
+# Hope you'll enjoy and contribute to this project,
+#     powered by Canal TP (www.canaltp.fr).
+# Help us simplify mobility and open public transport:
+#     a non ending quest to the responsive locomotion way of traveling!
+#
+# LICENCE: This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+# Stay tuned using
+# twitter @navitia
+# IRC #navitia on freenode
+# https://groups.google.com/d/forum/navitia
+# www.navitia.io
+from tests.utils import to_json, post
+import json
+
+
+def test_bad_coverage(app):
+    raw = post(app, '/coverages/unknown/data_sources',
+               '''{"id": "bob"}''')
+    r = to_json(raw)
+    assert raw.status_code == 400
+    assert r.get('message') == 'Bad coverage unknown.'
+
+
+def test_missing_data_source_id(app, coverage):
+    raw = post(app, '/coverages/jdr/data_sources',
+               '''{}''')
+    r = to_json(raw)
+    assert raw.status_code == 400
+    assert r.get('message') == 'Missing data_source_id attribute in request body.'
+
+
+def test_unknown_data_source(app, coverage):
+    raw = post(app, '/coverages/jdr/data_sources',
+               '''{"id": "bob"}''')
+    r = to_json(raw)
+    assert raw.status_code == 400
+    assert r.get('message') == 'Unknown data_source_id bob.'
+
+
+def test_add_data_source(app, coverage, data_source):
+    raw = post(app, '/coverages/jdr/data_sources',
+               json.dumps({"id": data_source.get('id')}))
+    r = to_json(raw)
+    assert raw.status_code == 200
+    data_sources = r.get('coverages')[0].get('data_sources')
+    assert isinstance(data_sources, list)
+    assert len(data_sources) == 1
+    assert data_sources[0] == data_source.get('id')
+
+    # test add existing data_source in coverage
+    raw = post(app, '/coverages/jdr/data_sources',
+               json.dumps({"id": data_source.get('id')}))
+    r = to_json(raw)
+    assert raw.status_code == 400
+    assert r.get('message') == 'Data source id {} already exists in coverage jdr.'.format(data_source.get('id'))


### PR DESCRIPTION
- Added new API POST /coverages/:id/data_sources
```json
{ "id": "8484-14545-14484" }
```

- GET /coverages/:id, POST /coverages, PATCH /coverages/:id now return an array of coverages
```json
{
  "coverages": [
    {
      ....
    }
  ]
}
```

Before
```json
{
  "coverages": {
      ...
  }
}
```

- DELETE /coverages/:id now return nothing