### PR TITLE
Contributors: return array of contributors

### DIFF
--- a/documentation/openAPI.yaml
+++ b/documentation/openAPI.yaml
@@ -332,10 +332,7 @@ paths:
         200:
           description: Array of contributors
           schema:
-            title: contributors
-            type: array
-            items:
-              $ref: '#/definitions/contributor_type'
+            $ref: '#/definitions/contributor_obj'
     post:
       summary: Create a new contributor
       tags:
@@ -394,8 +391,6 @@ paths:
       responses:
         204:
           description: Delete OK
-          schema:
-            $ref: '#/definitions/contributor_obj'
     patch:
       summary: Modify contributor info
       tags:
@@ -435,7 +430,6 @@ definitions:
         type: array
         items:
           $ref: "#/definitions/coverage"
-
   coverage:
     type: object
     properties:
@@ -484,8 +478,10 @@ definitions:
   contributor_obj:
     type: object
     properties:
-      contributor:
-        $ref: "#/definitions/contributor_type"
+      contributors:
+        type: array
+        items:
+          $ref: "#/definitions/contributor_type"
 
   contributor_type:
     type: object

--- a/tartare/interfaces/contributors.py
+++ b/tartare/interfaces/contributors.py
@@ -30,7 +30,6 @@
 from flask_restful import abort
 import flask_restful
 from pymongo.errors import PyMongoError, DuplicateKeyError
-from tartare import app
 from tartare.core import models
 import logging
 from flask import request
@@ -66,7 +65,7 @@ class Contributor(flask_restful.Resource):
                 'impossible to add contributor {}'.format(contributor))
             return {'error': str(e)}, 500
 
-        return {'contributor': contributor_schema.dump(models.Contributor.get(contributor_id)).data}, 201
+        return {'contributors': [contributor_schema.dump(models.Contributor.get(contributor_id)).data]}, 201
 
     def get(self, contributor_id=None):
         if contributor_id:
@@ -74,7 +73,7 @@ class Contributor(flask_restful.Resource):
             if c is None:
                 abort(404)
             result = schema.ContributorSchema().dump(c)
-            return {'contributor': result.data}, 200
+            return {'contributors': [result.data]}, 200
         contributors = models.Contributor.all()
         return {'contributors': schema.ContributorSchema(many=True).dump(contributors).data}, 200
 
@@ -82,7 +81,7 @@ class Contributor(flask_restful.Resource):
         c = models.Contributor.delete(contributor_id)
         if c == 0:
             abort(404)
-        return {'contributor': None}, 204
+        return "", 204
 
     def patch(self, contributor_id):
         # "data_prefix" field is not modifiable, impacts of the modification
@@ -133,4 +132,4 @@ class Contributor(flask_restful.Resource):
                 'impossible to update contributor with dataset {}'.format(request_data))
             return {'error': str(e)}, 500
 
-        return {'contributor': schema.ContributorSchema().dump(contributor).data}, 200
+        return {'contributors': [schema.ContributorSchema().dump(contributor).data]}, 200

--- a/tests/integration/mongo/conftest.py
+++ b/tests/integration/mongo/conftest.py
@@ -79,7 +79,7 @@ def contributor(app):
     contributor = app.post('/contributors',
                            headers={'Content-Type': 'application/json'},
                            data='{"id": "bob", "name": "bob", "data_prefix": "bob"}')
-    return to_json(contributor)['contributor']
+    return to_json(contributor)['contributors'][0]
 
 @pytest.fixture(scope="function")
 def data_source(app, contributor):

--- a/tests/integration/mongo/contributors_api_test.py
+++ b/tests/integration/mongo/contributors_api_test.py
@@ -117,7 +117,7 @@ def test_post_contrib_no_data_source(app):
     r = to_json(raw)
     print(r)
     assert raw.status_code == 200
-    assert len(r["contributor"]["data_sources"]) == 0
+    assert len(r["contributors"][0]["data_sources"]) == 0
 
 
 def test_delete_contributors_returns_success(app):
@@ -146,8 +146,8 @@ def test_update_contributor_name(app):
     r = to_json(raw)
 
     assert raw.status_code == 200
-    assert r["contributor"]['id'] == "id_test"
-    assert r["contributor"]['name'] == "new_name_test"
+    assert r["contributors"][0]['id'] == "id_test"
+    assert r["contributors"][0]['name'] == "new_name_test"
 
 
 def test_update_contributor_data_prefix_error(app):

--- a/tests/integration/mongo/data_sources_api_test.py
+++ b/tests/integration/mongo/data_sources_api_test.py
@@ -60,7 +60,7 @@ def test_post_contrib_one_data_source_without_id(app):
     r = to_json(raw)
     print(r)
     assert raw.status_code == 200, print(r)
-    assert len(r["contributor"]["data_sources"]) == 1
+    assert len(r["contributors"][0]["data_sources"]) == 1
 
 
 def test_post_ds_one_data_source_with_id(app):
@@ -91,7 +91,7 @@ def test_post_contrib_one_data_source_with_id(app):
     raw = app.get('/contributors/id_test/')
     r = to_json(raw)
     assert raw.status_code == 200, print(r)
-    assert len(r["contributor"]["data_sources"]) == 1
+    assert len(r["contributors"][0]["data_sources"]) == 1
 
 
 def test_post_ds_one_data_source_with_data_format(app):
@@ -123,8 +123,8 @@ def test_post_contrib_one_data_source_with_data_format(app):
     raw = app.get('/contributors/id_test/')
     r = to_json(raw)
     assert raw.status_code == 200, print(r)
-    assert len(r["contributor"]["data_sources"]) == 1
-    assert r["contributor"]["data_sources"][0]["data_format"] == "Neptune"
+    assert len(r["contributors"][0]["data_sources"]) == 1
+    assert r["contributors"][0]["data_sources"][0]["data_format"] == "Neptune"
 
 
 def test_post_ds_two_data_source(app):
@@ -160,8 +160,8 @@ def test_post_contrib_two_data_source(app):
     raw = app.get('/contributors/id_test/')
     r = to_json(raw)
     assert raw.status_code == 200, print(r)
-    assert len(r["contributor"]["data_sources"]) == 2
-    assert r["contributor"]["data_sources"][0]["id"] != r["contributor"]["data_sources"][1]["id"]
+    assert len(r["contributors"][0]["data_sources"]) == 2
+    assert r["contributors"][0]["data_sources"][0]["id"] != r["contributors"][0]["data_sources"][1]["id"]
 
 
 def test_patch_ds_data_source_with_full_contributor(app):
@@ -194,13 +194,12 @@ def test_patch_contrib_data_source_with_full_contributor(app):
     raw = post(app, '/contributors', json.dumps(post_data))
     r = to_json(raw)
     assert raw.status_code == 201, print(r)
-    r["contributor"]["data_sources"][0]["name"] = "name_modified"
-    print("patching data with ", json.dumps(r["contributor"]))
-    raw = patch(app, '/contributors/id_test', json.dumps(r["contributor"]))
+    r["contributors"][0]["data_sources"][0]["name"] = "name_modified"
+    raw = patch(app, '/contributors/id_test', json.dumps(r["contributors"][0]))
     r = to_json(raw)
     assert raw.status_code == 200, print(r)
-    assert len(r["contributor"]["data_sources"]) == 1
-    patched_data_source = r["contributor"]["data_sources"][0]
+    assert len(r["contributors"][0]["data_sources"]) == 1
+    patched_data_source = r["contributors"][0]["data_sources"][0]
     assert patched_data_source["name"] == "name_modified"
 
 
@@ -235,17 +234,17 @@ def test_patch_contrib_data_source_name_only(app):
     r = to_json(raw)
     assert raw.status_code == 201, print(r)
     new_data_source = {}
-    new_data_source["id"] = r["contributor"]["data_sources"][0]["id"]
+    new_data_source["id"] = r["contributors"][0]["data_sources"][0]["id"]
     new_data_source["name"] = "name_modified"
-    r["contributor"]["data_sources"][0] = new_data_source
+    r["contributors"][0]["data_sources"][0] = new_data_source
     data_source_list = {}
     data_source_list["data_sources"] = [new_data_source]
     print("patching data with ", json.dumps(data_source_list))
     raw = patch(app, '/contributors/id_test', json.dumps(data_source_list))
     r = to_json(raw)
     assert raw.status_code == 200, print(r)
-    assert len(r["contributor"]["data_sources"]) == 1
-    patched_data_source = r["contributor"]["data_sources"][0]
+    assert len(r["contributors"][0]["data_sources"]) == 1
+    patched_data_source = r["contributors"][0]["data_sources"][0]
     assert patched_data_source["name"] == "name_modified"
     assert patched_data_source["data_format"] == "Neptune"
 
@@ -299,17 +298,17 @@ def test_patch_contrib_one_data_source_name_of_two_and_add_one(app):
     r = to_json(raw)
     assert raw.status_code == 201, print(r)
     new_data_source = {}
-    new_data_source["id"] = r["contributor"]["data_sources"][1]["id"]
+    new_data_source["id"] = r["contributors"][0]["data_sources"][1]["id"]
     new_data_source["name"] = "name_modified"
-    r["contributor"]["data_sources"][0] = new_data_source
+    r["contributors"][0]["data_sources"][0] = new_data_source
     data_source_list = {}
     data_source_list["data_sources"] = [new_data_source, {"name":"data_source_3"}]
     print("patching data with ", json.dumps(data_source_list))
     raw = patch(app, '/contributors/id_test', json.dumps(data_source_list))
     r = to_json(raw)
     assert raw.status_code == 200, print(r)
-    assert len(r["contributor"]["data_sources"]) == 3
-    patched_data_sources = r["contributor"]["data_sources"]
+    assert len(r["contributors"][0]["data_sources"]) == 3
+    patched_data_sources = r["contributors"][0]["data_sources"]
     assert patched_data_sources[0]["data_format"] == "Neptune"
     assert patched_data_sources[1]["data_format"] == "Neptune"
     assert patched_data_sources[2]["data_format"] == "gtfs"


### PR DESCRIPTION
- GET /contributors/:id, POST /contributors, PATCH /contributors/:id now return an array of contributors
```json
{
  "contributors": [
    {
      "data_prefix": "bob",
      "data_sources": [],
      "id": "bob",
      "name": "bob"
    }
  ]
}
```

Before
```json
{
  "contributor": {
      "data_prefix": "bob",
      "data_sources": [],
      "id": "bob",
      "name": "bob"
  }
}
```

- DELETE /contributors/:id now return nothing