### PR TITLE
Fixed error message when duplicated contributor id

### DIFF
--- a/tartare/core/models.py
+++ b/tartare/core/models.py
@@ -32,7 +32,6 @@ from tartare import app
 from tartare.helper import to_doted_notation
 from gridfs import GridFS
 from bson.objectid import ObjectId
-import logging
 import pymongo
 import uuid
 

--- a/tartare/interfaces/contributors.py
+++ b/tartare/interfaces/contributors.py
@@ -27,7 +27,6 @@
 # https://groups.google.com/d/forum/navitia
 # www.navitia.io
 
-from flask_restful import abort
 import flask_restful
 from pymongo.errors import PyMongoError, DuplicateKeyError
 from tartare.core import models
@@ -37,6 +36,7 @@ from tartare.interfaces import schema
 from marshmallow import ValidationError
 import uuid
 from tartare.exceptions import InvalidArguments, DuplicateEntry, InternalServerError, ResourceNotFound
+
 
 
 class Contributor(flask_restful.Resource):
@@ -56,9 +56,9 @@ class Contributor(flask_restful.Resource):
         contributor_id = post_data["id"]
         try:
             contributor.save()
-        except DuplicateKeyError:
-            raise DuplicateEntry("Impossible to add contributor, data_prefix '{}' already used."
-                                 .format(request.json['data_prefix']))
+        except DuplicateKeyError as e:
+            raise DuplicateEntry("Impossible to add contributor, id {} or data_prefix {} already used."
+                                 .format(request.json['id'], request.json['data_prefix']))
         except PyMongoError:
             raise InternalServerError('Impossible to add contributor {}'.format(contributor))
 


### PR DESCRIPTION
In mongo _id is unique by default.
In contributor, data_prefix is also unique.
When we create a contributor with an existing id, the error message is wrong.

Before
```json
{
  "error": "Impossible to add contributor, data_prefix bob already used.",
  "message": "Duplicate entry"
}
```

After
```json
{
  "error": "Impossible to add contributor, id bob or data_prefix bob already used.",
  "message": "Duplicate entry"
}
```